### PR TITLE
Specifically send "all" version

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -65,7 +65,7 @@ $(function () {
       type: "POST",
       crossDomain: true,
       contentType : 'application/json',
-      data: "{}",
+      data: JSON.stringify({ ver : "all" }),
       processData:true,
       success: function (result) {
         launchTable(result);


### PR DESCRIPTION
Prepares for a master server update where the server will only return the specifically requested version (or all if the version is empty). Per default it would only return 0.2.4 though (as those clients won't set the field at all so to stay compatible it returns only 0.2.4 servers if that is the case)
